### PR TITLE
Fix ai chat window size twitching bug

### DIFF
--- a/editor/docks/ai_chat_dock.cpp
+++ b/editor/docks/ai_chat_dock.cpp
@@ -233,6 +233,9 @@ void AIChatDock::_notification(int p_notification) {
             embedding_status_label = memnew(Label);
             embedding_status_label->set_text("");
             embedding_status_label->set_modulate(Color(0.8, 0.8, 0.8));
+            // Set fixed minimum width to prevent layout twitching during dot animation
+            embedding_status_label->set_custom_minimum_size(Size2(80, 0));
+            embedding_status_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
             top_container->add_child(embedding_status_label);
 			
 			// Setup authentication UI
@@ -10006,7 +10009,7 @@ void AIChatDock::_set_embedding_status(const String &p_text, bool p_busy) {
 	embedding_status_dots = 0;
 	
 	if (p_busy) {
-		embedding_status_label->set_text(p_text + "...");
+		embedding_status_label->set_text(p_text + "   "); // Fixed width with 3 spaces
 		embedding_status_label->set_modulate(Color(1.0, 0.8, 0.0)); // Yellow for in-progress
 		if (embedding_status_timer) {
 			embedding_status_timer->start();
@@ -10026,9 +10029,10 @@ void AIChatDock::_on_embedding_status_tick() {
 	}
 	
 	embedding_status_dots = (embedding_status_dots + 1) % 4;
-	String dots = "";
+	// Use fixed-width animation to prevent layout twitching
+	String dots = "   "; // Always 3 spaces width
 	for (int i = 0; i < embedding_status_dots; i++) {
-		dots += ".";
+		dots = dots.substr(0, i) + "." + dots.substr(i + 1);
 	}
 	
 	embedding_status_label->set_text(embedding_status_base + dots);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix: AI Chat Dock embedding status animation causes UI twitching (ORC-12)

This PR resolves a UI bug (ORC-12) where the AI chat window would "twitch" or resize due to the "changing files" (embedding status) animation.

**Why this change?**
The embedding status label in the `AIChatDock` displayed an animated "..." pattern, varying from 0 to 3 dots. Since this label was part of an `HBoxContainer`, its changing text width caused the entire container's layout to constantly recalculate and shift, leading to a noticeable "twitching" effect on the chat window.

**How this change fixes the issue:**
1.  **Fixed Minimum Width:** The `embedding_status_label` now has a fixed minimum width. This prevents the label from changing its size and affecting the parent container's layout.
2.  **Fixed-Width Animation:** The animation logic for the dots has been updated to operate within a fixed-width string (e.g., "Indexing   " -> "Indexing.  " -> "Indexing.. " -> "Indexing..."). This ensures the visual length of the text remains constant, eliminating layout shifts while still providing progress feedback.

These changes provide a stable UI experience by preventing unwanted layout recalculations caused by the animation.

---
Linear Issue: [ORC-12](https://linear.app/orcaengine/issue/ORC-12/the-default-size-of-the-ai-chat-window-causes-the-side-to-constantly)

<a href="https://cursor.com/background-agent?bcId=bc-d0e6a9dd-a92c-41e1-9048-ba70740770a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0e6a9dd-a92c-41e1-9048-ba70740770a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

