### PR TITLE
Fix agent streaming end indication and add sound

### DIFF
--- a/editor/docks/ai_chat_dock.cpp
+++ b/editor/docks/ai_chat_dock.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/text_edit.h"
 #include "scene/gui/tree.h"
 #include "scene/main/scene_tree.h"
+#include "servers/display_server.h"
 
 // Initialize static singleton
 AIChatDock *AIChatDock::singleton = nullptr;
@@ -3733,6 +3734,9 @@ void AIChatDock::_on_apply_edit_thread_done() {
     }
 
     if (pending_tool_tasks == 0) {
+        // All async tool tasks completed - show tool completion notification
+        _show_status_notification("completion", "Tool execution completed", "🔧", 2.0);
+        
         current_assistant_message_label = nullptr;
         _send_chat_request();
     }
@@ -7409,15 +7413,37 @@ void AIChatDock::_update_ui_state() {
 	send_button->set_disabled(input_field->get_text().strip_edges().is_empty() || is_waiting_for_response);
 	input_field->set_editable(!is_waiting_for_response);
 
-	// Handle stop button state
+	// Handle stop button state with improved reliability
 	if (is_waiting_for_response) {
 		// Show stop button and hide/disable send button during request
 		send_button->set_visible(false);
 		stop_button->set_visible(true);
-		bool should_disable_stop = current_request_id.is_empty();
-		stop_button->set_disabled(should_disable_stop); // Only enable if we have a request ID
 		
-		print_line("AI Chat: UI State - waiting for response, stop button visible=" + String(stop_button->is_visible() ? "true" : "false") + ", disabled=" + String(should_disable_stop ? "true" : "false") + ", request_id='" + current_request_id + "'");
+		// More robust stop button state - enable if we have a request ID or any pending work
+		bool has_active_request = !current_request_id.is_empty();
+		bool has_pending_work = pending_tool_tasks > 0;
+		bool should_enable_stop = has_active_request || has_pending_work;
+		
+		stop_button->set_disabled(!should_enable_stop);
+		
+		// Update stop button appearance to indicate activity
+		if (should_enable_stop) {
+			// Red background for active stop button
+			Ref<StyleBoxFlat> stop_style = memnew(StyleBoxFlat);
+			stop_style->set_bg_color(Color(0.8, 0.2, 0.2)); // Red
+			stop_style->set_corner_radius_all(6);
+			stop_style->set_content_margin_all(8);
+			stop_button->add_theme_style_override("normal", stop_style);
+			
+			// Slightly lighter red for hover
+			Ref<StyleBoxFlat> stop_hover_style = memnew(StyleBoxFlat);
+			stop_hover_style->set_bg_color(Color(0.9, 0.3, 0.3)); // Lighter red
+			stop_hover_style->set_corner_radius_all(6);
+			stop_hover_style->set_content_margin_all(8);
+			stop_button->add_theme_style_override("hover", stop_hover_style);
+		}
+		
+		print_line("AI Chat: UI State - waiting for response, stop button visible=" + String(stop_button->is_visible() ? "true" : "false") + ", enabled=" + String(should_enable_stop ? "true" : "false") + ", request_id='" + current_request_id + "', pending_tasks=" + String::num_int64(pending_tool_tasks));
 		
 		// Also disable new conversation button during processing
 		if (new_conversation_button) {
@@ -7428,6 +7454,10 @@ void AIChatDock::_update_ui_state() {
 		send_button->set_visible(true);
 		send_button->set_text("Send");
 		stop_button->set_visible(false);
+		
+		// Reset stop button styling when hidden
+		stop_button->remove_theme_style_override("normal");
+		stop_button->remove_theme_style_override("hover");
 		
 		print_line("AI Chat: UI State - not waiting, send button visible, stop button hidden");
 		
@@ -7456,6 +7486,26 @@ void AIChatDock::_request_completed() {
 		stop_requested = false;
 		current_request_id = "";
 		
+		// Show completion notification and play sound when fully done
+		_show_completion_notification();
+		
+		// Play system beep sound for audio feedback
+		if (DisplayServer::get_singleton()) {
+			DisplayServer::get_singleton()->beep();
+		}
+		
+		// Brief visual feedback on send button to indicate completion
+		if (send_button && send_button->is_inside_tree()) {
+			// Temporarily change send button text to show completion
+			send_button->set_text("✓ Done");
+			
+			// Use a timer to reset the button text after a short delay
+			SceneTree *tree = get_tree();
+			if (tree) {
+				tree->create_timer(1.5)->connect("timeout", callable_mp(this, &AIChatDock::_reset_send_button_text));
+			}
+		}
+		
 		// NOW clear the input field since the conversation is truly complete
 		if (input_field && input_field->is_inside_tree()) {
 			input_field->set_text("");
@@ -7482,6 +7532,13 @@ String AIChatDock::_get_timestamp() {
 	return String::num_int64(time_dict["hour"]).pad_zeros(2) + ":" +
 		   String::num_int64(time_dict["minute"]).pad_zeros(2);
 }
+
+void AIChatDock::_reset_send_button_text() {
+	if (send_button && send_button->is_inside_tree() && !is_waiting_for_response) {
+		send_button->set_text("Send");
+	}
+}
+
 String AIChatDock::_process_inline_markdown(String p_line) {
 	String line = p_line;
 
@@ -10918,6 +10975,10 @@ void AIChatDock::_show_status_notification(const String &p_type, const String &p
 		bg_color = get_theme_color(SNAME("success_color"), SNAME("Editor")) * Color(1, 1, 1, 0.15);
 		border_color = get_theme_color(SNAME("success_color"), SNAME("Editor"));
 		text_color = get_theme_color(SNAME("success_color"), SNAME("Editor"));
+	} else if (p_type == "completion") {
+		bg_color = get_theme_color(SNAME("success_color"), SNAME("Editor")) * Color(1, 1, 1, 0.15);
+		border_color = get_theme_color(SNAME("success_color"), SNAME("Editor"));
+		text_color = get_theme_color(SNAME("success_color"), SNAME("Editor"));
 	} else if (p_type == "rate_limit") {
 		bg_color = get_theme_color(SNAME("warning_color"), SNAME("Editor")) * Color(1, 1, 1, 0.15);
 		border_color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
@@ -10951,6 +11012,8 @@ void AIChatDock::_show_status_notification(const String &p_type, const String &p
 	if (icon_text.is_empty()) {
 		if (p_type == "summarization") {
 			icon_text = "🧠";
+		} else if (p_type == "completion") {
+			icon_text = "✅";
 		} else if (p_type == "rate_limit") {
 			icon_text = "⚠️";
 		} else if (p_type == "connection_error") {
@@ -11025,6 +11088,10 @@ void AIChatDock::_show_model_switch_notification(const String &p_from_provider, 
 	format_args.push_back(p_reason);
 	String message = String("Switched from {0} to {1}. Reason: {2}").format(format_args);
 	_show_status_notification("model_switch", message, "🔄", 4.0);
+}
+
+void AIChatDock::_show_completion_notification() {
+	_show_status_notification("completion", "AI response completed", "✅", 2.5);
 }
 
 void AIChatDock::_hide_status_notification() {

--- a/editor/docks/ai_chat_dock.h
+++ b/editor/docks/ai_chat_dock.h
@@ -372,6 +372,7 @@ private:
 
 	// Request completion helper
 	void _request_completed();
+	void _reset_send_button_text();
 
 	// Helper to truncate overly large text before sending to the model
 	String _truncate_text_for_context(const String &p_text, int p_max_chars = MAX_TEXT_ATTACHMENT_PREVIEW_CHARS);
@@ -558,6 +559,7 @@ private:
 	void _show_connection_status_notification(const String &p_status, const String &p_message = "");
 	void _show_rate_limit_notification(const String &p_provider, const String &p_message);
 	void _show_model_switch_notification(const String &p_from_provider, const String &p_to_provider, const String &p_reason);
+	void _show_completion_notification();
 	void _hide_status_notification();
 	void _on_status_notification_timer_timeout();
 	PanelContainer *status_notification_panel = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix: Improve AI Chat completion indication and stop button reliability (ORC-16)

This PR addresses the lack of clear indication when the AI agent finishes streaming and fixes the unreliable state of the stop button.

**Problem:**
Users found it unclear when the AI agent completed its response, and the stop button would sometimes incorrectly revert to an inactive state while the agent was still processing (e.g., during model switching due to rate limits). There was also no audio cue for completion.

**Solution:**
*   **Enhanced Completion Feedback:**
    *   A visual notification banner ("AI response completed") now appears upon the agent's final response.
    *   The send button temporarily displays "✓ Done" for 1.5 seconds after completion.
    *   A system beep sound is played to provide audio confirmation.
    *   A separate notification is shown when async tool executions complete.
*   **Reliable Stop Button:**
    *   The stop button's state management is improved to accurately reflect all ongoing work, including pending tool tasks.
    *   The active stop button now features a more prominent red background to clearly indicate when the agent is busy.

These changes provide a more intuitive and reliable user experience, ensuring users are always aware of the agent's status.

---
Linear Issue: [ORC-16](https://linear.app/orcaengine/issue/ORC-16/current-indication-at-the-end-of-agent-answer-streaming-is-not-working)

<a href="https://cursor.com/background-agent?bcId=bc-bf6bcc53-be77-44af-93bc-7f0a558406a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf6bcc53-be77-44af-93bc-7f0a558406a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

