### PR TITLE
Fix ui theme override bug

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -262,7 +262,8 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		Color system_base_color = display_server->get_base_color();
 		Color system_accent_color = display_server->get_accent_color();
 
-		if (follow_system_theme) {
+		// Preserve user's custom theme settings - only apply system theme if user hasn't customized
+		if (follow_system_theme && config.preset != "Custom") {
 			String dark_theme = "Default";
 			String light_theme = "Light";
 
@@ -335,14 +336,28 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_extra_borders", config.draw_extra_borders);
 		}
 
-		if (follow_system_theme && system_base_color != Color(0, 0, 0, 0)) {
+		// Only override with system colors if user hasn't already customized their theme
+		String original_preset = EDITOR_GET("interface/theme/preset");
+		if (follow_system_theme && system_base_color != Color(0, 0, 0, 0) && original_preset != "Custom") {
 			config.base_color = system_base_color;
 			config.preset = "Custom";
 		}
 
-		if (use_system_accent_color && system_accent_color != Color(0, 0, 0, 0)) {
+		if (use_system_accent_color && system_accent_color != Color(0, 0, 0, 0) && original_preset != "Custom") {
 			config.accent_color = system_accent_color;
 			config.preset = "Custom";
+		}
+
+		// Additional protection: if user had custom colors, preserve the Custom preset
+		// This fixes the issue where Orca would override Godot UI color settings
+		Color original_base_color = EDITOR_GET("interface/theme/base_color");
+		Color original_accent_color = EDITOR_GET("interface/theme/accent_color");
+		// Check against default values: base_color defaults to (0,0,0), accent_color defaults to (0.8,0.8,0.8)
+		if (original_preset == "Custom" && (original_base_color != Color(0, 0, 0) || original_accent_color != Color(0.8, 0.8, 0.8))) {
+			// User has custom colors, preserve them regardless of system theme settings
+			config.preset = "Custom";
+			config.base_color = original_base_color;
+			config.accent_color = original_accent_color;
 		}
 
 		// Enforce values in case they were adjusted or overridden.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix: Preserve user custom UI theme settings (ORC-14)

This PR resolves ORC-14, where the engine was overriding user-defined custom UI colors from Godot settings.

**Why this change?**
The `EditorThemeManager`'s `_create_theme_config` function in `editor/themes/editor_theme_manager.cpp` had logic that would:
1. Unintentionally change the `interface/theme/preset` from "Custom" to "Default" or "Light" when `follow_system_theme` was active.
2. Subsequently, it would overwrite user-defined `base_color` and `accent_color` with preset defaults because the `preset` was no longer "Custom".
3. These overridden settings were then permanently saved, causing custom UI colors to be lost.

**How it's fixed:**
The theme configuration logic is updated to:
- Prevent system theme detection from overriding the `preset` if it was originally "Custom".
- Ensure system base/accent color application only occurs if the user has not explicitly set custom colors.
- Add a safeguard to explicitly restore the "Custom" preset and user-defined colors if they were present, preventing unintended overrides.

This ensures that user-defined custom UI themes are preserved, while still allowing system theme following for users who haven't customized their settings.

---
Linear Issue: [ORC-14](https://linear.app/orcaengine/issue/ORC-14/the-engine-doesnt-read-you-godot-settings-for-ui-colour)

<a href="https://cursor.com/background-agent?bcId=bc-a80426ca-4196-4901-aa14-2f7ff483c4fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a80426ca-4196-4901-aa14-2f7ff483c4fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

