### PR TITLE
Fix chat auto-scroll bug

### DIFF
--- a/editor/docks/ai_chat_dock.cpp
+++ b/editor/docks/ai_chat_dock.cpp
@@ -3965,9 +3965,14 @@ void AIChatDock::_scroll_to_bottom_smooth() {
 
 void AIChatDock::_on_chat_content_min_size_changed() {
 	// Only auto-scroll when the user is already at the bottom.
-	if (auto_scroll_at_bottom) {
+	// Check current position in real-time to avoid forcing scroll during streaming
+	// when user has scrolled up to read previous messages.
+	bool is_at_bottom = _is_at_bottom();
+	if (is_at_bottom) {
 		call_deferred("_scroll_to_bottom");
 	}
+	// Update the cached state to keep it in sync
+	auto_scroll_at_bottom = is_at_bottom;
 }
 
 String AIChatDock::_truncate_text_for_context(const String &p_text, int p_max_chars) {

--- a/scroll_fix_verification.md
+++ b/scroll_fix_verification.md
@@ -1,0 +1,50 @@
+# AI Chat Auto-Scroll Fix Verification
+
+## Issue Description
+The AI chat was forcing scroll to bottom during streaming responses, making it impossible for users to scroll up and read previous messages while the agent was still typing.
+
+## Root Cause Analysis
+The `_on_chat_content_min_size_changed()` function was using a cached `auto_scroll_at_bottom` state that wasn't updated during streaming content changes. This caused forced scrolling even when users had manually scrolled up.
+
+## Fix Implementation
+Modified `_on_chat_content_min_size_changed()` in `/workspace/editor/docks/ai_chat_dock.cpp` to:
+
+1. **Real-time Position Check**: Instead of relying on cached state, check actual scroll position using `_is_at_bottom()`
+2. **Conditional Scrolling**: Only auto-scroll if user is genuinely at the bottom
+3. **State Synchronization**: Update cached `auto_scroll_at_bottom` to keep it in sync
+
+## Code Changes
+```cpp
+// Line 3966-3976 in ai_chat_dock.cpp
+void AIChatDock::_on_chat_content_min_size_changed() {
+    // Only auto-scroll when the user is already at the bottom.
+    // Check current position in real-time to avoid forcing scroll during streaming
+    // when user has scrolled up to read previous messages.
+    bool is_at_bottom = _is_at_bottom();
+    if (is_at_bottom) {
+        call_deferred("_scroll_to_bottom");
+    }
+    // Update the cached state to keep it in sync
+    auto_scroll_at_bottom = is_at_bottom;
+}
+```
+
+## Expected Behavior After Fix
+- ✅ User sends message → Auto-scroll enabled (normal behavior)
+- ✅ During streaming → Only scrolls if user is at bottom
+- ✅ User scrolls up during streaming → Scroll position preserved
+- ✅ User scrolls back to bottom → Auto-scroll re-enabled
+- ✅ Streaming completes → Normal scrolling behavior maintained
+
+## Testing Strategy
+1. Start a conversation with the AI
+2. Send a message that will generate a long response
+3. While the response is streaming, try to scroll up to read previous messages
+4. Verify that the scroll position is maintained and not forced back to bottom
+5. Scroll back to bottom manually and verify auto-scroll resumes
+
+## Files Modified
+- `/workspace/editor/docks/ai_chat_dock.cpp` (lines 3966-3976)
+
+## Linear Issue Resolution
+This fix resolves Linear issue ORC-44: "ai chat force scrolls to the bottom when a new agent message appears"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix: AI chat no longer force scrolls during streaming (ORC-44)

This PR resolves an issue where the AI chat would force scroll to the bottom during streaming responses, even if the user had scrolled up to read previous messages.

The problem stemmed from `_on_chat_content_min_size_changed` relying on a cached `auto_scroll_at_bottom` state that wasn't updated during content expansion.

The fix modifies `_on_chat_content_min_size_changed` to:
- Check the real-time scroll position using `_is_at_bottom()`.
- Only trigger auto-scroll if the user is genuinely at the bottom.
- Keep the `auto_scroll_at_bottom` state synchronized with the actual scroll position.

This ensures that users can scroll up during streaming without interruption, while still maintaining expected auto-scroll behavior when they are at the bottom or when a new message is initially sent.

---
Linear Issue: [ORC-44](https://linear.app/orcaengine/issue/ORC-44/ai-chat-force-scrolls-to-the-bottom-when-a-new-agent-message-appears)

<a href="https://cursor.com/background-agent?bcId=bc-486ebf9a-f2f1-46c1-97c8-3c797d06680b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-486ebf9a-f2f1-46c1-97c8-3c797d06680b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

