### PR TITLE
ci: gate code signing to release tags only

### DIFF
--- a/.github/workflows/macos-clean.yml
+++ b/.github/workflows/macos-clean.yml
@@ -3,8 +3,6 @@ name: 🍎 macOS Clean Build
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches: [ main ]
 
 permissions:
   contents: write

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -36,12 +36,16 @@ jobs:
   macos-build:
     name: 🍎 macOS Production
     needs: static-checks
+    # Cost guard: signing + notarization only on v* release tags or manual dispatch, never on plain push/PR.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/macos-clean.yml
     secrets: inherit
 
   windows-build:
     name: 🏁 Windows Production
     needs: static-checks
+    # Cost guard: SSL.com CodeSignTool signing only on v* release tags or manual dispatch, never on plain push/PR.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/windows-production.yml
     secrets: inherit
 

--- a/.github/workflows/windows-production.yml
+++ b/.github/workflows/windows-production.yml
@@ -3,8 +3,6 @@ name: 🏁 Windows Production Build
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches: [ main ]
 
 permissions:
   contents: write


### PR DESCRIPTION
Stops SSL.com eSigner + Apple notarytool from running on every push to main (cost leak). Signing/notarize now only reachable via v* release tags or manual dispatch, mirroring the merged orca-client-desktop / orca-chatbot fixes.

Changes:
- macos-clean.yml: removed `push: branches:[main]` trigger (kept workflow_call + workflow_dispatch). Signs via codesign + notarizes via xcrun notarytool.
- windows-production.yml: removed `push: branches:[main]` trigger (kept workflow_call + workflow_dispatch). Signs via SSL.com CodeSignTool (SSL_COM_* secrets).
- runner.yml (orchestrator, on: [push, pull_request, merge_group]): gated the macos-build and windows-build jobs that `uses:` the two signing workflows with `if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'`. Without this, every push/PR would still sign via workflow_call.

Net: no push/PR event can reach CodeSignTool/eSigner or notarytool. Signing only on a v* tag push or manual dispatch. Non-signing CI builds (static checks, android/ios/linux/web) still run on push.